### PR TITLE
Fix transparency in overview bug.

### DIFF
--- a/dynamic-panel-transparency@rockon999.github.io/extension.js
+++ b/dynamic-panel-transparency@rockon999.github.io/extension.js
@@ -126,6 +126,8 @@ function unmodify_panel() {
     Theming.reapply_panel_styling();
     Theming.reapply_panel_background_image();
 
+    Theming.remove_panel_transparency();
+
     /* Remove shadowing */
     if (Theming.has_text_shadow()) {
         Theming.remove_text_shadow();

--- a/dynamic-panel-transparency@rockon999.github.io/stylesheet.css
+++ b/dynamic-panel-transparency@rockon999.github.io/stylesheet.css
@@ -1,5 +1,9 @@
 /* Used to remove odd effects when full transparency is needed. */
 
+.panel-transparency {
+  background-color: rgba(0, 0, 0, 0);
+}
+
 .panel-effect-transparency {
   box-shadow: none;
   border: none;

--- a/dynamic-panel-transparency@rockon999.github.io/theming.js
+++ b/dynamic-panel-transparency@rockon999.github.io/theming.js
@@ -317,6 +317,22 @@ function get_unmaximized_opacity() {
 }
 
 /**
+ * Applies the style class 'panel-transparency' which makes the panel fully transparent.
+ *
+ */
+function apply_panel_transparency() {
+    Panel.add_style_class_name('panel-transparency');
+}
+
+/**
+ * Applies the style class 'panel-transparency' which makes the panel fully transparent.
+ *
+ */
+function remove_panel_transparency() {
+    Panel.remove_style_class_name('panel-transparency');
+}
+
+/**
  * Applies the style class 'panel-effect-transparency' and removes the basic CSS preventing this extension's transitions.
  *
  */

--- a/dynamic-panel-transparency@rockon999.github.io/transitions.js
+++ b/dynamic-panel-transparency@rockon999.github.io/transitions.js
@@ -74,6 +74,8 @@ function fade_in() {
         Theming.reapply_panel_background_image();
     }
 
+    Theming.remove_panel_transparency();
+
     if (Settings.enable_custom_background_color()) {
         Theming.set_maximized_background_color('custom');
 
@@ -143,6 +145,8 @@ function fade_out() {
         Theming.remove_maximized_background_color('custom');
     }
 
+    Theming.remove_panel_transparency();
+
     // TODO: Figure out how to write the panel corners in pure CSS.
     if (!Settings.get_hide_corners()) {
         let speed = St.Settings.get().slow_down_factor * Settings.get_transition_speed();
@@ -187,14 +191,16 @@ function fade_out() {
  *
  */
 function blank_fade_out() {
+    this.status.set_transparent(true);
+    this.status.set_blank(true);
+
     /* Completely remove every possible background style... */
     Theming.remove_background_color();
 
     Theming.strip_panel_background_image();
     Theming.strip_panel_styling();
 
-    this.status.set_transparent(true);
-    this.status.set_blank(true);
+    Theming.apply_panel_transparency();
 
     // TODO: These corners...
     if (!Settings.get_hide_corners()) {


### PR DESCRIPTION
Fixes #113.

A previous pull request proposed a fix, but the underlying issue was a bit more complicated. Essentially we need to set an explicit alpha CSS when we want to "blank" fade out. (in the overview we don't apply minimum transparency, we apply 0)